### PR TITLE
Jalesse/arm64 port

### DIFF
--- a/ssc_interface_wrapper_ros2/README.md
+++ b/ssc_interface_wrapper_ros2/README.md
@@ -1,3 +1,79 @@
 # Overview
 
 root workspace for ROS2 version of SCC interface wrapper
+
+# Setting up the environment
+## Clone/switch to the scc repo/ssc_interface_wrapper_ros2
+```sh
+$ git clone git@github.com:KBR-CARMA/carma-ssc-interface-wrapper.git
+# or
+cd ~/carma-ssc-interface-wrapper/ssc_interface_wrapper_ros2
+```
+
+## Switch to feature branch
+```sh
+$ git checkout <my-feature-branch> 
+```
+## Get latest 
+```sh
+$ git pull
+```
+
+## Go back to main repo
+```sh
+$ cd ~/carma-ssc-interface-wrapper
+```
+
+# Launching the CARMA container 
+Pull the current c1tenth image quitter.tech/carma-platform:c1tenth-develop 
+Launch under name "dev"
+mounting the scc interface as a volume and bash into it
+
+```sh
+$ docker run -it --rm --name dev -v $PWD/ssc_interface_wrapper_ros2:/home/carma/ssc_interface_wrapper_ros2 quitter.tech/carma-platform:c1tenth-develop bash
+```
+## The prompt should now look something like this
+```sh
+carma@a1d099b96ab7:/$
+```
+## Start a new terminal session to avoid ROS source issues
+```sh
+docker exec -it dev bash
+carma@b45d56a34bc:/$
+```
+## Create a workspace inside the container
+```sh 
+carma $ mkdir -p ~/tmp_ws/src  
+carma $ cd ~/tmp_ws/src
+```
+## Create a symlink to the package
+```sh 
+carma $ ln -s /home/carma/ssc_interface_wrapper_ros2
+carma $ cd ~/tmp_ws
+```
+## Source the container for ROS2 and check that it's pure ROS2
+```sh
+carma $ source /opt/carma/install_ros2/setup.bash
+carma $ printenv | grep ROS
+```
+## install and update dependencies
+```sh
+sudo apt update
+sudo apt-get install ros-foxy-pacmod3
+rosdep install --from-paths src --ignore-src -r -y
+```
+
+## Build the packages
+```sh
+carma $ cd ~/tmp_ws
+carma $ colcon build --event-handlers console_direct+ --packages-up-to ssc_interface_wrapper_ros2
+```
+
+## Source the package
+```sh
+carma $ source install/setup.bash
+```
+## Launch the package
+```sh
+carma $ ros2 launch carma-ssc-interface-wrapper ssc_interface_wrapper.launch.py
+```

--- a/ssc_interface_wrapper_ros2/README.md
+++ b/ssc_interface_wrapper_ros2/README.md
@@ -1,0 +1,3 @@
+# Overview
+
+root workspace for ROS2 version of SCC interface wrapper

--- a/ssc_interface_wrapper_ros2/README.md
+++ b/ssc_interface_wrapper_ros2/README.md
@@ -75,5 +75,5 @@ carma $ source install/setup.bash
 ```
 ## Launch the package
 ```sh
-carma $ ros2 launch carma-ssc-interface-wrapper ssc_interface_wrapper.launch.py
+carma $ ros2 launch ssc_interface_wrapper_ros2 ssc_interface_wrapper.launch.py
 ```

--- a/ssc_interface_wrapper_ros2/package.xml
+++ b/ssc_interface_wrapper_ros2/package.xml
@@ -25,7 +25,7 @@
   
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>carma_cmake_common</build_depend>
-  <build_depend>ament_auto_cmake</build_depend>
+  <build_depend>ament_cmake_auto</build_depend>
 
   <depend>rclcpp</depend>
   <depend>carma_ros2_utils</depend>


### PR DESCRIPTION
# PR Details
## Description

This is an attempt to setup and build ssc_interface_wrapper_ros2
It is obviously just a quick POC from FHWA because it's not it's own repo which is what it should be
We need this wrapper for c1tenth, though it's not clear why.  FHWA appears to be building c1tenth 
from f1tenth as separate entity from "Big Car CARMA".  F1tenth does not use any Autoware or AutonousStuff packages so 
this SCC package seems to be in direct conflict with c1t 

## Issues

- The package is currently not building because it's trying to pull in Autoware.ai packages which are ROS 1
- There is no evidence that the ROS2 version of this package ever compiled.
- There is also no evidence that the FHWA CARAMA develop branch is complete or working since it's very vague as to what it's trying to accomplish
- We are basing the KBR port of CARMA to arm64 from the 4.2.0 CARMA version which is ROS 1. This was decided because of the desire to get the Port Drayage demo working on c1tenth/ROS2 which is not part of the Volpe c1t POC
- This is causing multiple issues because of the mixture of ROS1/2 on the CARMA develop branch as well as a mix of components from c1tenth FHWA CARAM 

## Build output
```
CMake Error at /opt/autoware.ai/ros/install/cav_msgs/share/cav_msgs/cmake/cav_msgsConfig.cmake:197 (find_package):
  Could not find a package configuration file provided by "message_runtime"
  with any of the following names:

    message_runtimeConfig.cmake
    message_runtime-config.cmake

  Add the installation prefix of "message_runtime" to CMAKE_PREFIX_PATH or
  set "message_runtime_DIR" to a directory containing one of the above files.
  If "message_runtime" provides a separate development package or SDK, be
  sure it has been installed.
Call Stack (most recent call first):
  /opt/autoware.ai/ros/install/cav_srvs/share/cav_srvs/cmake/cav_srvsConfig.cmake:197 (find_package)
  /opt/ros/foxy/share/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake:67 (find_package)
  CMakeLists.txt:25 (ament_auto_find_build_dependencies)


-- Configuring incomplete, errors occurred!
See also "/home/carma/tmp_ws/build/ssc_interface_wrapper_ros2/CMakeFiles/CMakeOutput.log".
See also "/home/carma/tmp_ws/build/ssc_interface_wrapper_ros2/CMakeFiles/CMakeError.log".
--- stderr: ssc_interface_wrapper_ros2                           
CMake Error at /opt/autoware.ai/ros/install/cav_msgs/share/cav_msgs/cmake/cav_msgsConfig.cmake:197 (find_package):
  Could not find a package configuration file provided by "message_runtime"
  with any of the following names:

    message_runtimeConfig.cmake
    message_runtime-config.cmake

  Add the installation prefix of "message_runtime" to CMAKE_PREFIX_PATH or
  set "message_runtime_DIR" to a directory containing one of the above files.
  If "message_runtime" provides a separate development package or SDK, be
  sure it has been installed.
Call Stack (most recent call first):
  /opt/autoware.ai/ros/install/cav_srvs/share/cav_srvs/cmake/cav_srvsConfig.cmake:197 (find_package)
  /opt/ros/foxy/share/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake:67 (find_package)
  CMakeLists.txt:25 (ament_auto_find_build_dependencies)


---
Failed   <<< ssc_interface_wrapper_ros2 [27.9s, exited with code 1]

Summary: 0 packages finished [29.1s]
  1 package failed: ssc_interface_wrapper_ros2
  1 package had stderr output: ssc_interface_wrapper_ros2
carma@217dc841e6f0:~/tmp_ws$ 
```
